### PR TITLE
Add time ranges to menu items

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import { Box, CssBaseline, Grid } from '@mui/material';
+import Sidebar from './components/Sidebar';
+import DashboardPanel from './components/DashboardPanel';
+import { fetchMetrics, getMetricQueries } from './services/prometheusService';
+
+function App() {
+  const [selectedPanel, setSelectedPanel] = useState('overview');
+  const [metricsData, setMetricsData] = useState({
+    chunks: [],
+    targetCount: [],
+    targetLatency: [],
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [chunksData, targetCountData, targetLatencyData] = await Promise.all([
+          fetchMetrics(getMetricQueries.chunks.query, getMetricQueries.chunks.timeRange),
+          fetchMetrics(getMetricQueries.targetCount.query, getMetricQueries.targetCount.timeRange),
+          fetchMetrics(getMetricQueries.targetLatency.query, getMetricQueries.targetLatency.timeRange),
+        ]);
+
+        setMetricsData({
+          chunks: chunksData[0]?.values.map(([timestamp, value]) => ({
+            timestamp: new Date(timestamp * 1000).toLocaleTimeString(),
+            value: parseFloat(value),
+          })) || [],
+          targetCount: targetCountData[0]?.values.map(([timestamp, value]) => ({
+            timestamp: new Date(timestamp * 1000).toLocaleTimeString(),
+            value: parseFloat(value),
+          })) || [],
+          targetLatency: targetLatencyData[0]?.values.map(([timestamp, value]) => ({
+            timestamp: new Date(timestamp * 1000).toLocaleTimeString(),
+            value: parseFloat(value) * 1000, // Convert to milliseconds
+          })) || [],
+        });
+      } catch (error) {
+        console.error('Error fetching metrics:', error);
+      }
+    };
+
+    fetchData();
+    const interval = setInterval(fetchData, 15000); // Refresh every 15 seconds
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const renderPanels = () => {
+    if (selectedPanel === 'overview') {
+      return (
+        <>
+          <Grid item xs={12} md={4}>
+            <DashboardPanel title="TSDB Chunks Creation Rate (30m)" data={metricsData.chunks} />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <DashboardPanel title="Target Count (1h)" data={metricsData.targetCount} />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <DashboardPanel title="Target Latency (5m)" data={metricsData.targetLatency} />
+          </Grid>
+        </>
+      );
+    }
+
+    const panelData = {
+      chunks: { title: 'TSDB Chunks Creation Rate (30m)', data: metricsData.chunks },
+      targetCount: { title: 'Target Count (1h)', data: metricsData.targetCount },
+      targetLatency: { title: 'Target Latency (5m)', data: metricsData.targetLatency },
+    }[selectedPanel];
+
+    return (
+      <Grid item xs={12}>
+        <DashboardPanel title={panelData.title} data={panelData.data} />
+      </Grid>
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <Sidebar onMenuSelect={setSelectedPanel} />
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: 3,
+          width: { sm: `calc(100% - 240px)` },
+          ml: { sm: `240px` },
+        }}
+      >
+        <Grid container spacing={3}>
+          {renderPanels()}
+        </Grid>
+      </Box>
+    </Box>
+  );
+}
+
+export default App;

--- a/src/components/DashboardPanel.js
+++ b/src/components/DashboardPanel.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Paper, Typography } from '@mui/material';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+const DashboardPanel = ({ title, data }) => {
+  return (
+    <Paper sx={{ p: 2, height: '100%' }}>
+      <Typography variant="h6" gutterBottom>
+        {title}
+      </Typography>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="timestamp" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#8884d8" />
+        </LineChart>
+      </ResponsiveContainer>
+    </Paper>
+  );
+};
+
+export default DashboardPanel;

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Drawer, List, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Dashboard, Storage, Speed, Timer } from '@mui/icons-material';
+
+const drawerWidth = 240;
+
+const Sidebar = ({ onMenuSelect }) => {
+  const menuItems = [
+    { text: 'Overview', icon: <Dashboard />, id: 'overview' },
+    { text: 'TSDB Chunks (30m)', icon: <Storage />, id: 'chunks' },
+    { text: 'Target Count (1h)', icon: <Speed />, id: 'targetCount' },
+    { text: 'Target Latency (5m)', icon: <Timer />, id: 'targetLatency' },
+  ];
+
+  return (
+    <Drawer
+      variant="permanent"
+      sx={{
+        width: drawerWidth,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: drawerWidth,
+          boxSizing: 'border-box',
+        },
+      }}
+    >
+      <div style={{ padding: '20px' }}>
+        <Typography variant="h6">Prometheus Metrics</Typography>
+      </div>
+      <List>
+        {menuItems.map((item) => (
+          <ListItem
+            button
+            key={item.id}
+            onClick={() => onMenuSelect(item.id)}
+          >
+            <ListItemIcon>{item.icon}</ListItemIcon>
+            <ListItemText primary={item.text} />
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
This PR updates the dashboard UI:

- Add time ranges to menu items:
  - TSDB Chunks (30m)
  - Target Count (1h)
  - Target Latency (5m)
- Improve panel titles to show time ranges
- Make each metric individually accessible

The dashboard now clearly shows the time range for each metric in both the menu and panel titles.